### PR TITLE
Bump parsy upper bound

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'Topic :: Text Processing',
     ],
     install_requires=[
-        'parsy>=1.2.0,<1.3.0',
+        'parsy>=1.2.0,<2.2',
     ],
 
     packages=[


### PR DESCRIPTION
It does not look like there have been breaking changes other than Python version bump: https://parsy.readthedocs.io/en/latest/history.html

Tests still green.